### PR TITLE
Improve binary path collection

### DIFF
--- a/pipx/main.py
+++ b/pipx/main.py
@@ -131,8 +131,8 @@ class Venv:
             dist = pkg_resources.get_distribution("{package}")
             bin_path = "{self.bin_path}"
             binaries = set()
-            for _, d in pkg_resources.get_entry_map(dist).items():
-                for binary in d:
+            for section in ['console_scripts', 'gui_scripts']:
+                for binary in pkg_resources.get_entry_map(dist).get(section, []):
                     binaries.add(binary)
 
             if dist.has_metadata('RECORD'):


### PR DESCRIPTION
Based on
https://packaging.python.org/specifications/entry-points/#use-for-scripts
the entry points should only be in the console_scripts and
gui_scripts sections.

This should help prevent nbconvert from pulling python as a dependency binary in #18 