### PR TITLE
add dependencies to an existing pipx-managed virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,25 @@ Upgrades all packages within their virtual environments by running `pip install 
 pipx upgrade-all
 ```
 
+### inject
+Adds a package to an existing pipx-managed virtual environment.
+
+```
+pipx inject PACKAGE DEPENDENCY
+```
+
+#### inject example
+
+One use of the inject command is setting up a REPL with some useful extra packages.
+
+```
+pipx install ptpython
+pipx inject ptpython requests
+pipx inject ptpython pendulum
+```
+
+After running the above commands, you will be able to import and use the `requests` and `pendulum` packages inside a `ptpython` repl.
+
 ### uninstall
 Uninstalls a package by deleting its virtual environment and any symlinks that point to its binaries.
 ```

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -488,12 +488,12 @@ def install(
     print(f"done! {stars}")
 
 
-def inject(venv_dir: Path, package: str, package_or_url: str, verbose: bool):
+def inject(venv_dir: Path, package: str, verbose: bool):
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(f"Can't inject {package} into nonexistent venv {venv_dir}!")
 
     venv = Venv(venv_dir, verbose=verbose)
-    venv.install_package(package_or_url)
+    venv.install_package(package)
 
     if venv.get_package_version(package) is None:
         raise PipxError(f"Could not find package {package}. Is the name correct?")
@@ -605,10 +605,7 @@ def run_pipx_command(args):
             force=args.force,
         )
     elif args.command == "inject":
-        package_or_url = (
-            args.spec if ("spec" in args and args.spec is not None) else args.dependency
-        )
-        inject(venv_dir, args.dependency, package_or_url, verbose)
+        inject(venv_dir, args.dependency, verbose)
     elif args.command == "upgrade":
         package_or_url = (
             args.spec if ("spec" in args and args.spec is not None) else package
@@ -748,7 +745,6 @@ def get_command_parser():
         "package", help="Name of the existing pipx-managed virtualenv to inject into"
     )
     p.add_argument("dependency", help="the package to inject into the virtualenv")
-    p.add_argument("--spec", help=SPEC_HELP)
     p.add_argument("--verbose", action="store_true")
 
     p = subparsers.add_parser("upgrade", help="Upgrade a package")

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -59,7 +59,7 @@ PIPX_HOME and PIPX_BIN_DIR, respectively.
 )
 PIPX_USAGE = """
     %(prog)s [--spec SPEC] [--python PYTHON] BINARY [BINARY-ARGS]
-    %(prog)s {install, upgrade, upgrade-all, uninstall, uninstall-all, reinstall-all, list} [--help]"""
+    %(prog)s {install, inject, upgrade, upgrade-all, uninstall, uninstall-all, reinstall-all, list} [--help]"""
 
 
 def print_version() -> None:
@@ -488,6 +488,24 @@ def install(
     print(f"done! {stars}")
 
 
+def inject(
+        venv_dir: Path,
+        package: str,
+        package_or_url: str,
+        verbose: bool):
+    if not venv_dir.exists() or not next(venv_dir.iterdir()):
+        raise PipxError(f"Can't inject {package} into nonexistent venv {venv_dir}!")
+
+    venv = Venv(venv_dir, verbose=verbose)
+    venv.install_package(package_or_url)
+
+    if venv.get_package_version(package) is None:
+        raise PipxError(f"Could not find package {package}. Is the name correct?")
+
+    _list_installed_package(venv_dir)
+    print(f"done! {stars}")
+
+
 def uninstall(venv_dir: Path, package: str, local_bin_dir: Path, verbose: bool):
     if not venv_dir.exists():
         print(f"Nothing to uninstall for {package} 😴")
@@ -589,6 +607,16 @@ def run_pipx_command(args):
             args.python,
             verbose,
             force=args.force,
+        )
+    elif args.command == "inject":
+        package_or_url = (
+            args.spec if ("spec" in args and args.spec is not None) else args.dependency
+        )
+        inject(
+            venv_dir,
+            args.dependency,
+            package_or_url,
+            verbose,
         )
     elif args.command == "upgrade":
         package_or_url = (
@@ -722,6 +750,12 @@ def get_command_parser():
         help="The Python binary to associate the CLI binary with. Must be v3.3+.",
     )
 
+    p = subparsers.add_parser("inject", help="Install a package into an existing virtualenv")
+    p.add_argument("package", help="name of the existing pipx-managed virtualenv to inject into")
+    p.add_argument("dependency", help="the package to inject into the virtualenv")
+    p.add_argument("--spec", help=SPEC_HELP)
+    p.add_argument("--verbose", action="store_true")
+
     p = subparsers.add_parser("upgrade", help="Upgrade a package")
     p.add_argument("package")
     p.add_argument("--spec", help=SPEC_HELP)
@@ -813,6 +847,7 @@ def cli():
     """Entry point from command line"""
     pipx_commands = [
         "install",
+        "inject",
         "upgrade",
         "upgrade-all",
         "uninstall",

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -745,7 +745,7 @@ def get_command_parser():
         "inject", help="Install a package into an existing virtualenv"
     )
     p.add_argument(
-        "package", help="name of the existing pipx-managed virtualenv to inject into"
+        "package", help="Name of the existing pipx-managed virtualenv to inject into"
     )
     p.add_argument("dependency", help="the package to inject into the virtualenv")
     p.add_argument("--spec", help=SPEC_HELP)

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -498,7 +498,6 @@ def inject(venv_dir: Path, package: str, verbose: bool):
     if venv.get_package_version(package) is None:
         raise PipxError(f"Could not find package {package}. Is the name correct?")
 
-    _list_installed_package(venv_dir)
     print(f"done! {stars}")
 
 

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -488,11 +488,7 @@ def install(
     print(f"done! {stars}")
 
 
-def inject(
-        venv_dir: Path,
-        package: str,
-        package_or_url: str,
-        verbose: bool):
+def inject(venv_dir: Path, package: str, package_or_url: str, verbose: bool):
     if not venv_dir.exists() or not next(venv_dir.iterdir()):
         raise PipxError(f"Can't inject {package} into nonexistent venv {venv_dir}!")
 
@@ -612,12 +608,7 @@ def run_pipx_command(args):
         package_or_url = (
             args.spec if ("spec" in args and args.spec is not None) else args.dependency
         )
-        inject(
-            venv_dir,
-            args.dependency,
-            package_or_url,
-            verbose,
-        )
+        inject(venv_dir, args.dependency, package_or_url, verbose)
     elif args.command == "upgrade":
         package_or_url = (
             args.spec if ("spec" in args and args.spec is not None) else package
@@ -750,8 +741,12 @@ def get_command_parser():
         help="The Python binary to associate the CLI binary with. Must be v3.3+.",
     )
 
-    p = subparsers.add_parser("inject", help="Install a package into an existing virtualenv")
-    p.add_argument("package", help="name of the existing pipx-managed virtualenv to inject into")
+    p = subparsers.add_parser(
+        "inject", help="Install a package into an existing virtualenv"
+    )
+    p.add_argument(
+        "package", help="name of the existing pipx-managed virtualenv to inject into"
+    )
     p.add_argument("dependency", help="the package to inject into the virtualenv")
     p.add_argument("--spec", help=SPEC_HELP)
     p.add_argument("--verbose", action="store_true")


### PR DESCRIPTION
Hi, I've been using pipx for a little while now and I really like it!

One thing I found myself doing quite often was running commands like the following to add useful packages to my `ptpython` REPL:

```shell
~/.local/pipx/venvs/ptpython/bin/pip install requests
```

I would also occasionally do this to add an optional dependency for a package I'd previously installed with `pipx`.

I spent some time prototyping a feature for pipx called "inject" that wraps this into a convenient command. It's probably a little rough around the edges as this was my first proper foray into the pipx code base.

Here is a little snapshot of me playing with the new command, to demonstrate what it does:

```
$ pipx inject ptpython requests
Can't inject requests into nonexistent venv /home/chris/.local/pipx/venvs/ptpython!

$ pipx install ptpython
  installed package ptpython, 2.0.4
  These binaries are now globally available
    - ptipython
    - ptipython3
    - ptipython3.6
    - ptpython
    - ptpython3
    - ptpython3.6
done!

$ ptpython
In [1]: import requests
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'requests'

No module named 'requests'
In [2]: exit()

$ pipx inject ptpython requests
   package ptpython, 2.0.4
    - ptipython
    - ptipython3
    - ptipython3.6
    - ptpython
    - ptpython3
    - ptpython3.6
done!

$ ptpython
In [1]: import requests
In [2]: requests.get('https://httpbin.org/get')
Out[2]: <Response [200]>
```

Please let me know if you think this could be a useful addition to pipx.