### PR TITLE
Tests package should be excluded from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 CURDIR = os.path.abspath(os.path.dirname(__file__))
 
-EXCLUDE_FROM_PACKAGES = []
+EXCLUDE_FROM_PACKAGES = ['tests']
 REQUIRED = []
 
 with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:


### PR DESCRIPTION
Tests package should be excluded from distribution, otherwise they end up being deployed to the site-packages root when using `python setup.py install`.

This is what happens in the [Arch Linux package](https://aur.archlinux.org/packages/python-pipx), it conflicts with another one that has the same issue:
```
error: failed to commit transaction (conflicting files)
python-pipx: /usr/lib/python3.7/site-packages/tests/__init__.py exists in filesystem (owned by borgmatic)
python-pipx: /usr/lib/python3.7/site-packages/tests/__pycache__/__init__.cpython-37.opt-1.pyc exists in filesystem (owned by borgmatic)
python-pipx: /usr/lib/python3.7/site-packages/tests/__pycache__/__init__.cpython-37.pyc exists in filesystem (owned by borgmatic)
Errors occurred, no packages were upgraded.
```